### PR TITLE
fix build: deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ out/
 CMakeCache.txt
 CMakeFiles/
 CMakeScripts/
+CMakeUserPresets.json
 cmake_install.cmake
+compile_commands.json
 install_manifest.txt
 CTestTestfile.cmake
 Testing/
@@ -48,6 +50,7 @@ tg-fuse
 *.pdb
 
 # Dependency files
+deps/
 *.d
 
 # Core dumps
@@ -90,3 +93,5 @@ tdlib/
 # Claude local settings
 .claude
 
+# Others
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Dependencies source dir to avoid (re-)download sources into build dir
+set(DEPS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps" CACHE PATH "Directory for dependency sources")
+
 # Include FetchContent for dependency management
 include(FetchContent)
 
@@ -65,6 +68,7 @@ FetchContent_Declare(
     nlohmann_json
     GIT_REPOSITORY https://github.com/nlohmann/json.git
     GIT_TAG v3.11.3
+    SOURCE_DIR ${DEPS_SOURCE_DIR}/nlohmann_json
 )
 
 # Fetch spdlog
@@ -72,6 +76,7 @@ FetchContent_Declare(
     spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
     GIT_TAG v1.13.0
+    SOURCE_DIR ${DEPS_SOURCE_DIR}/spdlog
 )
 
 # Fetch CLI11
@@ -79,6 +84,7 @@ FetchContent_Declare(
     cli11
     GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
     GIT_TAG v2.4.1
+    SOURCE_DIR ${DEPS_SOURCE_DIR}/cli11
 )
 
 # Fetch GoogleTest
@@ -86,6 +92,7 @@ FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG v1.14.0
+    SOURCE_DIR ${DEPS_SOURCE_DIR}/googletest
 )
 
 # Fetch TDLib
@@ -93,6 +100,8 @@ FetchContent_Declare(
     tdlib
     GIT_REPOSITORY https://github.com/tdlib/td.git
     GIT_TAG master
+    GIT_PROGRESS TRUE
+    SOURCE_DIR ${DEPS_SOURCE_DIR}/tdlib
 )
 
 # Fetch fmt library
@@ -100,6 +109,8 @@ FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
     GIT_TAG 10.2.1
+    SOURCE_DIR ${DEPS_SOURCE_DIR}/fmt
+    OVERRIDE_FIND_PACKAGE # bustache tries to find it via find_package
 )
 
 # Fetch bustache (mustache templating)
@@ -109,12 +120,13 @@ FetchContent_Declare(
     bustache
     GIT_REPOSITORY https://github.com/jamboree/bustache.git
     GIT_TAG master
+    SOURCE_DIR ${DEPS_SOURCE_DIR}/bustache
 )
 
 # Find SQLite3 (system library)
 find_package(SQLite3 REQUIRED)
 
-# Make dependencies available (fmt before spdlog since spdlog uses external fmt)
+# Make dependencies available (fmt before spdlog and bustache since they use it)
 FetchContent_MakeAvailable(nlohmann_json fmt spdlog cli11 googletest tdlib bustache)
 
 # Enable testing for our project only (after dependencies are loaded)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,6 @@ FetchContent_Declare(
     tdlib
     GIT_REPOSITORY https://github.com/tdlib/td.git
     GIT_TAG master
-    GIT_PROGRESS TRUE
     SOURCE_DIR ${DEPS_SOURCE_DIR}/tdlib
 )
 


### PR DESCRIPTION
* Make bustache use the downloaded fmt library
* Avoid downloading dependency sources into the build directory
    * No need to re-download deps for separate Debug and Release builds
    * Build dir can be completely wiped with no mercy if any